### PR TITLE
Lemmas typos

### DIFF
--- a/guides/advancing-proofs/README.md
+++ b/guides/advancing-proofs/README.md
@@ -80,4 +80,4 @@ kontrol build --require kontrol/myproject-lemmas.k --module-import MyProjectTest
 
 ### Finding Lemmas
 
-In the next sections, we will explore how to find  **KEVM** lemmas, which are used to address reasoning gaps at the EVM semantic level.
+In the next section, we will explore how to find  **KEVM** lemmas, which are used to address reasoning gaps at the EVM semantic level.

--- a/guides/advancing-proofs/README.md
+++ b/guides/advancing-proofs/README.md
@@ -21,9 +21,9 @@ When these situations arise, the way to progress past them is to identify the mi
 
 ## Intro to Lemmas
 
-Lemmas can be seen as one-step reasoning processes that you want **Kontrol** to be consider during symbolic execution of your properties.
+Lemmas can be seen as one-step reasoning processes that you want **Kontrol** to consider during symbolic execution of your properties.
 
-Similar to `rewrite` rules, lemmas have a left-hand side (LHS) and a right-hand side (RHS). When **Kontrol** identifies a symbolic match for the LHS in the **K** configuration of a proof, it applies the rule and rewrits the LHS to the RHS.&#x20;
+Similar to `rewrite` rules, lemmas have a left-hand side (LHS) and a right-hand side (RHS). When **Kontrol** identifies a symbolic match for the LHS in the **K** configuration of a proof, it applies the rule and rewrites the LHS to the RHS.&#x20;
 
 ### Structure of a Lemma
 
@@ -36,7 +36,7 @@ rule [name-of-lemma]: <k> LHS(X, Y) => RHS(X, Y) </k>
   [simplification]
 ```
 
-In short, lemmas are simplification rules, specifically, **K** rewrites rules with the `simplification` attribute. You can include other attributes in addition to `simplification`. Below is a list of commonly used attributes when defining lemmas:
+In short, lemmas are simplification rules, specifically, **K** rewrite rules with the `simplification` attribute. You can include other attributes in addition to `simplification`. Below is a list of commonly used attributes when defining lemmas:
 
 * `smt-lemma`: passes the `simplification` rule down to the SMT-solver. To use this predicate, the functions in the lemma must be defined with the `smt-lib` attribute.
 * `concrete(VAR)`: applies the rule only when `VAR` can be matched to a concrete value
@@ -49,7 +49,6 @@ Multiple attributes can be separated by commas, for example: `[simplification, c
 To add lemmas to your project, create a file called: `myproject-lemmas.k`. This file is usually located in the `kontrol/` directory and should have the following structure:
 
 ```
-requires "evm.md"
 requires "foundry.md"
 
 module MYPROJECT-LEMMAS
@@ -65,8 +64,8 @@ endmodule
 
 After creating this file, you need to inform **Kontrol** about the lemmas in the file so that it can reason with them. This can be done during the `build` phase of your project. To include `test/myproject-lemmas.k` in the reasoning capabilities of **Kontrol**, the following flags should be included:
 
-* `--require test/myproject-lemmas.k` : specifies the file from which file the module `MYPROJECT-LEMMAS` is imported.
-* `--module-import MyProjectTests:MYPROJECT-LEMMAS`: provide to location of the file. The module name is preceded by the string `MyProjectTests:` , which represents the contract name for the tests being symbolically executed.
+* `--require test/myproject-lemmas.k` : specifies from which file the module `MYPROJECT-LEMMAS` is imported.
+* `--module-import MyProjectTests:MYPROJECT-LEMMAS`: specifies the module to import. The module name is preceded by the string `MyProjectTests:` , which represents the contract name for the tests being symbolically executed.
 * `--rekompile` (optional): rebuild the project. It is necessary to include the `--rekompile` flag when adding new lemmas, otherwise **Kontrol** won't be aware of them.&#x20;
 
 You can find more information about `build` flags here: [#kontrol-build](../../cheatsheets/kontrol-cheatsheet.md#kontrol-build "mention")
@@ -81,4 +80,4 @@ kontrol build --require kontrol/myproject-lemmas.k --module-import MyProjectTest
 
 ### Finding Lemmas
 
-In the following sections, we will explore how to find two different types of lemmas: **KEVM** lemmas and arithmetical lemmas. **KEVM** lemmas are used to address reasoning gaps at the EVM semantic level, while arithmetical lemmas address the gaps related to arithmetic.
+In the next sections, we will explore how to find  **KEVM** lemmas, which are used to address reasoning gaps at the EVM semantic level.

--- a/guides/advancing-proofs/kevm-lemmas.md
+++ b/guides/advancing-proofs/kevm-lemmas.md
@@ -10,7 +10,7 @@ In this section, we will verify [Solady's](https://github.com/Vectorized/solady)
 kup install kontrol --version v0.1.12
 ```
 
-The reasoning engine behind **Kontrol** is the **K** framework and the **K** definition of the EVM semantics, **KEVM**. Sometimes it is necessary to address reasoning gaps or suggest simplification strategies at the **KEVM** level. To gain a better understanding of the definitions and rules involved in expressions that are not being simplified as desired, you can explore the [**KEVM** repository](https://github.com/runtimeverification/evm-semantics).
+The reasoning engine behind **Kontrol** is the **K** framework, which is accessed through the **K** definition of the EVM semantics, **KEVM**. Sometimes it is necessary to address reasoning gaps or suggest simplification strategies at the **KEVM** level. To gain a better understanding of the definitions and rules involved in expressions that are not being simplified as desired, you can explore the [**KEVM** repository](https://github.com/runtimeverification/evm-semantics).
 
 ## Verifying Solady's `mulWad`
 


### PR DESCRIPTION
This PR addresses the following typos in the `advancing-proofs` guide:

- Small syntactic typos
- Removes `evm.md` as an import from the lemmas template file
- Introduces some small style changes
- Rewords the end of the `README.md`, since it says there are two sections but in the web page there's only one section about KEVM lemmas