### PR TITLE
Fix Summary entries

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,10 +12,11 @@
   * [Property Verification using Kontrol](guides/kontrol-example/property-verification-using-kontrol.md)
   * [K Control Flow Graph (KCFG)](guides/kontrol-example/k-control-flow-graph-kcfg.md)
   * [Proof Management](guides/kontrol-example/proof-management.md)
-  * [Debugging a proof](guides/kontrol-example/linked-library-example.md)
+  * [Debugging a Proof](guides/kontrol-example/linked-library-example.md)
 * [Node Refutation](guides/node-refutation.md)
 * [Advancing Proofs](guides/advancing-proofs/README.md)
   * [KEVM Lemmas](guides/advancing-proofs/kevm-lemmas.md)
+  * [Symbolic Storage](guides/advancing-proofs/symbolic-storage.md)
 
 ## Cheatsheets
 


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/gitbook-kontrol/pull/61.

This PR adds a symbolic storage guide to the table of contents and fixes capitalization in another entry.