### PR TITLE
Make formula render in the simplifications guide

### DIFF
--- a/guides/advancing-proofs/simplifications-guide.md
+++ b/guides/advancing-proofs/simplifications-guide.md
@@ -16,7 +16,10 @@ The purpose of simplifications, as their name suggests, is to simplify the job o
 rule LHS => RHS requires C1 andBool ... andBool CN [simplification]
 ```
 
-meaning that all occurrences of the term `LHS` in the current symbolic state should be replaced with the term `RHS` when the Boolean constraints `C1`, ..., `CN` are entailed by the current path condition `PC`, that is, when $\mathtt{PC} \implies \mathtt{C1} \wedge \ldots \wedge \mathtt{CN}$.
+meaning that all occurrences of the term `LHS` in the current symbolic state should be replaced with the term `RHS` when the Boolean constraints `C1`, ..., `CN` are entailed by the current path condition `PC`, that is, when
+$$
+\mathtt{PC} \implies \mathtt{C1} \wedge \ldots \wedge \mathtt{CN}
+$$
 
 Importantly, a simplification is **sound** if and only if
 $$


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/gitbook-kontrol/pull/57.

Apparently, gitbook doesn't render inline latex math. This PR should fix it:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/a0dc98db-da96-4f96-849d-f01d1b6412f2">
