### PR TITLE
Little step missing in "Installations" page

### DIFF
--- a/overview/readme/installations.md
+++ b/overview/readme/installations.md
@@ -24,7 +24,7 @@ The simplest way to install **Kontrol** is with the `kup`[ ](https://github.com/
 bash <(curl https://kframework.org/install)
 ```
 
-After installing `kup`, install **Kontrol** using `kup` with the following command:
+After installing `kup`, open a new terminal session or reload your PATH and install **Kontrol** using `kup` with the following command:
 
 ```
 kup install kontrol


### PR DESCRIPTION
After installing Nix, the path needs to be reloaded or a new terminal session needs to be started.