### PR TITLE
Docs update: new cheatcode, dynamically-sized inputs guides, deepwiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ layout:
 
 To begin using Kontrol, check out our [installation guide](overview/readme/installations.md) and explore our [example projects](guides/kontrol-example/README.md) to see Kontrol in action.
 
+### Explore the Codebase with AI
+
+If you want to dive deeper into Kontrol's architecture and implementation, check out [**Kontrol on DeepWiki**](https://deepwiki.com/runtimeverification/kontrol)—an AI-powered interactive documentation that lets you ask questions about the codebase.
+
 ## Community
 
 Join our growing community on [Discord](https://discord.gg/CurfmXNtbN) to connect with other developers, share experiences, and get support.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,6 +12,7 @@
     * [K Control Flow Graph (KCFG)](guides/kontrol-example/k-control-flow-graph-kcfg.md)
     * [Proof Management](guides/kontrol-example/proof-management.md)
     * [Debugging a Proof](guides/kontrol-example/linked-library-example.md)
+    * [Handling Dynamically Sized Inputs](guides/kontrol-example/dynamic-types.md)
 * [Node Refutation](guides/node-refutation.md)
 * [Bytecode Verification](guides/bytecode-verification.md)
 * [Advancing Proofs](guides/advancing-proofs/README.md)

--- a/cheatsheets/cheatcodes.md
+++ b/cheatsheets/cheatcodes.md
@@ -10,6 +10,10 @@ For a comprehensive technical reference of all cheatcodes and their implementati
 
 If you notice a missing cheatcode, feel free to open an [issue](https://github.com/runtimeverification/kontrol/issues) or [contribute](https://github.com/runtimeverification/kontrol/blob/master/CONTRIBUTING.md) directly to the project.
 
+{% hint style="info" %}
+**Foundry Compatibility**: Kontrol also supports `console.log` statements for debugging, just like Foundry. You can use `console.log` to output debug information during verification runs, which is particularly useful when working with symbolic values and complex verification scenarios.
+{% endhint %}
+
 ## Available Cheatcodes
 
 ### Foundry-Compatible Cheatcodes
@@ -139,6 +143,28 @@ function testComplexMock() public {
 }
 ```
 
+#### Call Whitelisting
+```solidity
+function testCallWhitelisting() public {
+    address token = address(0x123);
+    address user = vm.randomAddress();
+    uint256 amount = vm.randomUint();
+    
+    // Allow only specific function calls to the token contract
+    bytes memory transferCalldata = abi.encodeWithSignature("transfer(address,uint256)", user, amount);
+    bytes memory balanceCalldata = abi.encodeWithSignature("balanceOf(address)", user);
+    
+    vm.allowCalls(token, transferCalldata);
+    vm.allowCalls(token, balanceCalldata);
+    
+    // These calls will be allowed during verification
+    token.transfer(user, amount);
+    uint256 balance = token.balanceOf(user);
+    
+    // Other calls to the token contract will be blocked
+    // token.approve(user, amount); // This would be blocked
+}
+```
 ### Kontrol-Specific Cheatcodes
 
 {% hint style="info" %}
@@ -186,6 +212,7 @@ Using Kontrol-specific cheatcodes will break compatibility with `forge test`, as
 4. Name your symbolic variables meaningfully when debugging
 5. Mock external calls to control their behavior during verification and isolate the contract under test
 6. Combine symbolic and concrete values strategically when appropriate
+7. Use `allowCalls*` cheatcodes for fine-grained control over external calls during verification, especially when you need to restrict which specific functions can be called on external contracts
 
 ## Limitations
 
@@ -235,7 +262,7 @@ Used for event verification:
 Used for controlling function calls and storage access during execution:
 - `<isCallWhitelistActive>`: Enables whitelist mode for calls
 - `<isStorageWhitelistActive>`: Enables whitelist mode for storage
-- `<addressList>`: List of whitelisted addresses that are allowed to be called
+- `<allowedCallsList>`: List of whitelisted `{address, calldata}` pairs that are allowed to be called
 - `<storageSlotList>`: List of whitelisted storage slots that are allowed to be modified
 
 ### Mock Calls Configuration

--- a/guides/kontrol-example/dynamic-types.md
+++ b/guides/kontrol-example/dynamic-types.md
@@ -1,0 +1,120 @@
+---
+description: How to work with dynamically sized types in Kontrol using NatSpec annotations
+---
+
+# Working with Dynamically Sized Inputs
+
+Kontrol provides powerful capabilities for working with dynamically sized types like arrays and byte arrays through NatSpec annotations. This allows you to specify constraints on symbolic variables that would otherwise have unbounded symbolic length, making proofs fail on compiler-inserted checks for calldata well-formedness.
+
+## Overview
+
+When working with symbolic execution, dynamically sized types like `bytes[]`, `uint256[]`, or `bytes` can have symbolic lengths, which can make verification complex or even impossible. Kontrol addresses this through custom NatSpec annotations that allow you to specify concrete sizes for these types.
+
+## NatSpec Annotations
+
+Kontrol supports two main NatSpec annotations for controlling dynamically sized types:
+
+- `@custom:kontrol-array-length-equals`: Specifies the number of elements in an array
+- `@custom:kontrol-bytes-length-equals`: Specifies the length of bytes or byte arrays
+
+### Basic Example
+
+```solidity
+/// @custom:kontrol-array-length-equals ba: 2,
+/// @custom:kontrol-bytes-length-equals ba: 600,
+function test_complex_type(bytes[] calldata ba) public {
+    require(ba.length == 2, "DynamicTypes: invalid length for bytes[]");
+    assert(ba[1].length == 600);
+}
+```
+
+In this example:
+- The `ba` array will have exactly 2 elements
+- Each element in `ba` will be exactly 600 bytes long
+- The verification will only explore cases where these constraints are satisfied
+
+## Real-World Example: Bridge Verification
+
+Inspired by [Optimism's proofs](https://github.com/ethereum-optimism/optimism/blob/c38ce096def52e4acdaecb7ffd2d396f464693dd/packages/contracts-bedrock/test/kontrol/proofs/OptimismPortal.k.sol), here's a simplified example of how you might verify a bridge contract that processes cross-chain messages:
+
+```solidity
+/// @custom:kontrol-array-length-equals proof: 3,
+/// @custom:kontrol-bytes-length-equals proof: 32,
+function test_process_message(
+    bytes calldata message,
+    bytes[] calldata proof,
+    uint256 blockNumber
+) public {
+    require(proof.length == 3, "Must have 3 proof elements");
+    require(proof[0].length == 32, "Each proof element must be 32 bytes");
+    
+    // Simulate processing a cross-chain message with merkle proof
+    bool success = bridgeContract.processMessage(message, proof, blockNumber);
+    assert(success);
+}
+```
+
+This test:
+- Constrains `proof` to have exactly 3 elements (typical for a merkle proof)
+- Each element in `proof` is exactly 32 bytes long (standard hash size)
+- Tests the bridge message processing with these specific constraints
+
+## Complex Types: Structs and Tuples
+
+For more complex scenarios involving structs or tuples with dynamic types, Kontrol supports constraining the dynamic elements within these structures:
+
+```solidity
+struct ComplexType {
+    uint256 id;
+    bytes content;
+}
+
+/// @custom:kontrol-array-length-equals ctValues: 10,
+/// @custom:kontrol-bytes-length-equals content: 10000,
+function test_dynamic_struct_array(ComplexType[] calldata ctValues) public {
+    require(ctValues.length == 10, "DynamicTypes: invalid length for ComplexType[]");
+    assert(ctValues[8].content.length == 10000); // this check was failing
+}
+```
+
+This example demonstrates:
+- A struct `ComplexType` with a `uint256` id and dynamic `bytes` content
+- Constraining the array `ctValues` to have exactly 10 elements
+- Each `content` field within the structs is exactly 10,000 bytes long
+- Verification that the 9th element (index 8) has the correct content length
+
+## Usage Patterns
+
+### Multiple Arrays
+
+You can constrain multiple arrays in the same function:
+
+```solidity
+/// @custom:kontrol-array-length-equals addresses: 3,
+/// @custom:kontrol-array-length-equals amounts: 3,
+/// @custom:kontrol-bytes-length-equals addresses: 20,
+function test_batch_transfer(
+    address[] calldata addresses,
+    uint256[] calldata amounts
+) public {
+    require(addresses.length == 3, "Must have 3 addresses");
+    require(amounts.length == 3, "Must have 3 amounts");
+    // Test logic here
+}
+```
+
+## Best Practices
+
+1. **Choose appropriate sizes**: Select sizes that are realistic for your use case but small enough for efficient verification
+2. **Document constraints**: Use clear comments explaining why specific sizes were chosen
+3. **Test edge cases**: Consider testing with different size combinations
+
+## Limitations
+
+- **Size constraints**: You must specify concrete sizes; symbolic lengths are not supported
+- **Performance**: Larger sizes can significantly impact verification performance
+- **Compatibility**: These annotations are Kontrol-specific and won't work with standard Foundry
+
+## References
+
+- [Optimism Kontrol Tests](https://github.com/ethereum-optimism/optimism/tree/c38ce096def52e4acdaecb7ffd2d396f464693dd/packages/contracts-bedrock/test/kontrol)

--- a/guides/kontrol-example/dynamic-types.md
+++ b/guides/kontrol-example/dynamic-types.md
@@ -83,26 +83,6 @@ This example demonstrates:
 - Each `content` field within the structs is exactly 10,000 bytes long
 - Verification that the 9th element (index 8) has the correct content length
 
-## Usage Patterns
-
-### Multiple Arrays
-
-You can constrain multiple arrays in the same function:
-
-```solidity
-/// @custom:kontrol-array-length-equals addresses: 3,
-/// @custom:kontrol-array-length-equals amounts: 3,
-/// @custom:kontrol-bytes-length-equals addresses: 20,
-function test_batch_transfer(
-    address[] calldata addresses,
-    uint256[] calldata amounts
-) public {
-    require(addresses.length == 3, "Must have 3 addresses");
-    require(amounts.length == 3, "Must have 3 amounts");
-    // Test logic here
-}
-```
-
 ## Best Practices
 
 1. **Choose appropriate sizes**: Select sizes that are realistic for your use case but small enough for efficient verification

--- a/learn-more/example-projects.md
+++ b/learn-more/example-projects.md
@@ -1,10 +1,10 @@
 ---
-description: Real-world projects and examples using Kontrol
+description: Code repositories, projects, and practical examples using Kontrol
 ---
 
 # Example Projects
 
-Here are some notable projects and examples that use Kontrol for formal verification:
+Here are notable projects and code repositories that use Kontrol for formal verification. These provide practical examples and templates for different use cases.
 
 ## Production Projects
 
@@ -18,21 +18,22 @@ Here are some notable projects and examples that use Kontrol for formal verifica
 ### Solady
 [Kontrol-Solady](https://github.com/runtimeverification/kontrol-solady) is a formal verification project for the Solady library, demonstrating how to verify commonly used smart contract patterns and optimizations.
 
-## Educational Resources
+### Lido Dual Governance
+[Lido's Dual Governance](https://github.com/lidofinance/dual-governance/tree/tests/kontrol-formal-verification/test/kontrol) uses Kontrol for formal verification of their dual governance mechanism.
 
-### Patrick Collins' Course
-[Cyfrin's Smart Contract Exploits Course](https://github.com/Cyfrin/sc-exploits-minimized/blob/main/test/invariant-break/formal-verification/KontrolTest.t.sol) includes Kontrol examples as part of their curriculum, showing how to use formal verification to prevent common vulnerabilities.
+## Educational Repositories
+
+### Kontrol Demo
+[Kontrol Demo](https://github.com/runtimeverification/kontrol-demo) is a simple repository demonstrating basic Kontrol usage, perfect for getting started with formal verification.
+
+### Uniswap Hooks
+[Uniswap Hooks Proofs](https://github.com/runtimeverification/uniswap-hooks) provides formal verification proofs for secure and modular Uniswap hooks. A detailed walkthrough of these proofs is available in the [Verified Hooks workshop video](https://www.youtube.com/watch?v=ubOfMnk0HZ0).
 
 ### Secureum Workshop
 The [Secureum Kontrol Workshop](https://github.com/runtimeverification/secureum-kontrol) provides hands-on examples and exercises for learning Kontrol, including:
 - Basic verification examples
 - Advanced proof techniques
 - Common patterns and best practices
-
-## Example Repositories
-
-### Kontrol Demo
-[Kontrol Demo](https://github.com/runtimeverification/kontrol-demo) is a simple repository demonstrating basic Kontrol usage, perfect for getting started with formal verification.
 
 ### DSS 2024
 [Kontrol DSS 2024](https://github.com/runtimeverification/kontrol-dss-2024) showcases more advanced usage patterns and verification techniques.
@@ -46,4 +47,8 @@ To explore these examples:
 3. Study the [Optimism implementation](https://github.com/ethereum-optimism/optimism/tree/c38ce096def52e4acdaecb7ffd2d396f464693dd/packages/contracts-bedrock/test/kontrol) for production usage
 4. Explore [Kontrol-Solady](https://github.com/runtimeverification/kontrol-solady) for library verification patterns
 
-Each project provides unique insights into how Kontrol can be used effectively in different contexts and for different purposes. 
+Each project provides unique insights into how Kontrol can be used effectively in different contexts and for different purposes.
+
+{% hint style="info" %}
+**Looking for learning materials instead?** Check out our [Resources](resources.md) page for videos, blog posts, and educational content.
+{% endhint %} 

--- a/learn-more/resources.md
+++ b/learn-more/resources.md
@@ -1,26 +1,56 @@
 ---
-description: If you want to learn more or get involved
+description: Learning materials, community, and educational resources for Kontrol
 ---
 
 # Resources
 
-Join the Community on [Discord](https://discord.gg/CurfmXNtbN)! If you have questions, feedback, or problems we would love to hear from you and offer support.
+Join the Community on [Discord](https://discord.gg/CurfmXNtbN) and [Telegram](https://t.me/rv_kontrol)! If you have questions, feedback, or problems we would love to hear from you and offer support.
 
-### Videos
-
-* [In Solidity Specification, Testing, and Verification](https://www.youtube.com/live/staXNgpBjEI?feature=shared)
+## Videos and Presentations
+* [Proofcast 105 - Learn Formal Verification in 45 minutes with Kontrol: ](https://www.youtube.com/watch?v=iOz8zv_89Bs)
+* [Foundry-based Formal Verification with Kontrol](https://www.youtube.com/watch?v=L61GfNMBc14)
+* [Verified Hooks: Security, Debugging, and Formal Verification for Uniswap v4](https://www.youtube.com/watch?v=ubOfMnk0HZ0)
+* [How To Get Security Under Kontrol](https://www.youtube.com/watch?v=dMoBd0F4cjQ)
+* [**K, KEVM, Kontrol** presentation video](https://www.youtube.com/watch?v=9PLnQStkiUo)
 * [Tackling Rounding Errors with Precision Analysis](https://youtu.be/nUfcsblYQH0)
 * [Formal Methods for the Working DeFi Dev](https://www.youtube.com/watch?v=ETlNhV9jYJw)
-* [Security: Auditing and Formal Methods](https://www.youtube.com/watch?v=W\_Rs3-Q8pAs)
+* [Security: Auditing and Formal Methods](https://www.youtube.com/watch?v=W_Rs3-Q8pAs)
 * [Towards Adoption of Symbolic Execution for DeFi Security](https://www.youtube.com/watch?v=Kjs0ZiZ7m9k)
-* [**K, KEVM, Kontrol** presentation video](https://www.youtube.com/watch?v=9PLnQStkiUo)
 
-### Blogs and Other Resources
+## Blog Posts and Articles
 
+* [Kontrol and Term Finance: Formal Verification Success Story Working with Bounded Loops](https://www.runtimeverification.com/blog/kontrol-and-term-finance-formal-verification-success-story-working-with-bounded-loops)
+* [Formally Verifying Loops: Part 1](https://www.runtimeverification.com/blog/formally-verifying-loops-part-1) and [Part 2](https://www.runtimeverification.com/blog/formally-verifying-loops-part-2)
+* [Using Kontrol to Tackle Complexities Caused by Dynamically-Sized Constructs](https://www.runtimeverification.com/blog/using-kontrol-to-tackle-complexities-caused-by-dynamically-sized-constructs)
+* [External Computation with Kontrol](https://www.runtimeverification.com/blog/external-computation-with-kontrol)
 * [Using Foundry to Explore Upgradeable Contracts (Part 1)](https://runtimeverification.com/blog/using-foundry-to-explore-upgradeable-contracts-part-1)
 * [Foundry: Gen 2 of Ethereum Tooling](https://runtimeverification.com/blog/foundry-gen-2-of-ethereum-tooling)
-* To learn more about Foundry check out the [Foundry Book](https://book.getfoundry.sh/)
-* **KEVM** and **Kontrol** are powered by the [**K** Framework](https://kframework.org/), if you are interested in learning more check out the [0 to **K** Tutorial](https://runtimeverification.com/blog/from-0-to-k-tutorial)
-* We also have formal verification on Algorand powered by **K**! Check out [**KAVM**](https://runtimeverification.com/blog/runtime-verification-brings-formal-verification-to-algorand)!
+* [From 0 to **K** Tutorial](https://runtimeverification.com/blog/from-0-to-k-tutorial)
 
-Did you see a typo somewhere in the Gitbook? Click the three dots on the page to suggest an edit on [Github](https://github.com/runtimeverification/gitbook-kontrol)!
+## Learning Resources
+
+### Patrick Collins' Course
+[Cyfrin's Smart Contract Exploits Course](https://github.com/Cyfrin/sc-exploits-minimized/blob/main/test/invariant-break/formal-verification/KontrolTest.t.sol) includes Kontrol examples as part of their curriculum, showing how to use formal verification to prevent common vulnerabilities.
+
+### Foundry
+* [Foundry Book](https://book.getfoundry.sh/) - Comprehensive guide to Foundry
+* [Foundry GitHub](https://github.com/foundry-rs/foundry) - Source code and issues
+
+### K Framework
+* [K Framework](https://kframework.org/) - The foundation of KEVM and Kontrol
+* [0 to K Tutorial](https://runtimeverification.com/blog/from-0-to-k-tutorial) - Learn the K Framework from scratch
+
+### Related Projects
+* [KEVM](https://github.com/runtimeverification/evm-semantics) - Ethereum Virtual Machine semantics in K
+* [KAVM](https://runtimeverification.com/blog/runtime-verification-brings-formal-verification-to-algorand) - Formal verification for Algorand
+* [Komet](https://github.com/runtimeverification/komet) - Testing and formal verification tool for Soroban smart contracts
+
+## Community and Support
+
+* [Discord](https://discord.gg/CurfmXNtbN) and [Telegram](https://t.me/rv_kontrol) community- Join discussions and get help
+* [Kontrol GitHub](https://github.com/runtimeverification/kontrol) - Source code, issues, and contributions
+* [GitBook Repository](https://github.com/runtimeverification/gitbook-kontrol) - Documentation source and suggestions
+
+{% hint style="info" %}
+**Found a typo or want to suggest improvements?** Click the three dots on any page to suggest an edit on [GitHub](https://github.com/runtimeverification/gitbook-kontrol)!
+{% endhint %}


### PR DESCRIPTION
This PR adds more info about the new `allowCalls` cheatcode, adds a page for NatSpec comments for dynamically-sized input types, and a link to Kontrol's DeepWiki page.